### PR TITLE
Komenda test-dev

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -21,6 +21,9 @@ tasks:
   test:
     cmds:
       - docker compose run --rm --build test
+  test-dev:
+    cmds:
+      - docker compose run --rm --build test_dev
   typecheck:
     cmds:
       - docker compose run --rm typecheck

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,6 +15,12 @@ services:
     volumes:
       - ./src:/usr/src/app:ro
     command: python -m unittest discover -q -b /usr/src/app
+  test_dev:
+    build: ./test
+    image: transactions2pln-test:latest
+    volumes:
+      - ./src:/usr/src/app:ro
+    command: python -W default -m unittest discover -b /usr/src/app
   typecheck:
     image: hbielenia/mypy:1.11-py3.11-bullseye@sha256:4ffa075473f57467d188d60cc762026a8ba466ee711cf762b33946123cefced4
     volumes:


### PR DESCRIPTION
Dodaje komendę test-dev, która wykonuje testy bez parametru `-q` (czyli z pełnym wyjściem) i z parametrem interpretera `-W default`.

Implementuje #5 . Implementacja z użyciem parametru interpretera `-X dev` okazała się niemożliwa, gdyż kod w `src/transactions2pln/script.py:155` sprawia, że w trybie deweloperskim błędy nie są przechwytywane. Ponieważ niektóre testy w `src/tests/test_script.py` testują właśnie przechwytywanie błędów, testy te zwracają błędy gdy są uruchamiane z parametrem `-X dev`. Zamiast tego, implementacja używa `-W default`, gdyż głównym celem tej komendy jest wychwycenie ostrzeżeń `DeprecationWarning` i `PendingDeprecationWarning` przy testowaniu z nowymi wersjami Pythona.