### PR TITLE
Migracja na Python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.rst"
 authors = [
 	{ name = "Hubert Bielenia", email = "hubert.bielenia@gmail.com" },
 ]
-requires-python = "~= 3.11"
+requires-python = "~= 3.12"
 keywords = [ "pln", "transactions data" ]
 classifiers = [
 	"Development Status :: 5 - Production/Stable",
@@ -20,7 +20,7 @@ classifiers = [
 	"Natural Language :: Polish",
 	"Operating System :: Microsoft :: Windows",
 	"Operating System :: POSIX :: Linux",
-	"Programming Language :: Python :: 3.11",
+	"Programming Language :: Python :: 3.12",
 	"Topic :: Office/Business :: Financial :: Accounting",
 	"Topic :: Office/Business :: Financial :: Investment",
 	"Topic :: Utilities",

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -17,7 +17,7 @@
 # pozwoleń i ograniczeń w ramach Licencji, należy zapoznać
 # się z treścią licencji.
 
-FROM python:3.11-bullseye@sha256:c927121ba6f075a139438db25b22e0c21df8ecae790958f5f3764c32e3c25834
+FROM python:3.12-bullseye@sha256:4da4396d9fa63e3f2014b56275ed261eba14b9c6ba51883f81341ee170e64103
 WORKDIR /usr/src/app
 RUN apt-get update \
 	&& apt-get install -y locales=2.31-13+deb11u11 \


### PR DESCRIPTION
Zmienia wspieraną wersję Pythona na 3.12, gdyż 3.11 wszedł w fazę maintenance.

Wymagane przez #1 .