### PR TITLE
Modyfikuj plik licencji tylko przy wykonywaniu po wypchnięciu taga

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,7 @@ jobs:
         shell: bash
         run: mv ./build/exe.win-amd64-${{ steps.python.outputs.version }}/python312.dll ./build/exe.win-amd64-${{ steps.python.outputs.version }}/python3.dll
       - name: Modyfikacja pliku z licencją
+        if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') }}
         shell: bash
         run: |-
             mv ./build/exe.win-amd64-${{ steps.python.outputs.version }}/frozen_application_license.txt ./build/exe.win-amd64-${{ steps.python.outputs.version }}/license.txt


### PR DESCRIPTION
Ustawia warunek dla kroku modyfikującego plik licencji tak, by krok wykonywał się tylko po wypchnięciu taga, podobnie jak następny krok z zapisaniem artefaktu. Zmiana wynika z tego, że modyfikacja licencji wydaje się być zbędna jako krok przy sprawdzaniu PR-ów.

Implementuje #11 .