### PR TITLE
Bardziej elastyczne odwołanie do pliku python312.dll

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
         run: docker compose run --rm --quiet-pull build_exe
       - name: Zmiana nazwy biblioteki Pythona by uniknąć ostrzeżenia przy uruchamianiu
         shell: bash
-        run: mv ./build/exe.win-amd64-${{ steps.python.outputs.version }}/python312.dll ./build/exe.win-amd64-${{ steps.python.outputs.version }}/python3.dll
+        run: mv ./build/exe.win-amd64-${{ steps.python.outputs.version }}/python3*.dll ./build/exe.win-amd64-${{ steps.python.outputs.version }}/python3.dll
       - name: Modyfikacja pliku z licencją
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') }}
         shell: bash


### PR DESCRIPTION
Zamienia sufiks pliku dll wygenerowanego przez cx_Freeze na operator wildcard (`*`), dzięki czemu odpowiedni krok workflow GH Actions jest bardziej kompatybilny z przyszłymi wersjami.

Naprawia #11.