### PR TITLE
Wyzwalanie wokflow build przy wypchnięciu tagów

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,8 @@ on:
       - 'src/transactions2pln/**.py'
       - '.github/workflows/build.yml'
   push:
+    tags:
+      - '*'
     branches:
       - 'master'
     paths:


### PR DESCRIPTION
Konfiguruje workflow GH Actions `build` tak, aby wyzwalało go wypchnięcie tagów do repozytorium.

Naprawia #15.