### PR TITLE
Naprawia błąd występujący, gdy kolumna z walutą jest pierwsza

### DIFF
--- a/src/transactions2pln/script.py
+++ b/src/transactions2pln/script.py
@@ -250,7 +250,7 @@ def transactions2pln(
 		try:
 			currency_column_idx: int|None = utils.get_column_index(
 				args.currency, labels)
-			assert currency_column_idx
+			assert currency_column_idx is not None
 		except (AssertionError, ValueError) as err:
 			# Jeżeli nie możemy uzyskać indeksu, zwracamy błąd.
 			raise exc.ColumnParameterError('currency', args.currency) from err


### PR DESCRIPTION
Naprawia błąd z wykrywaniem kolumny z walutą który występuje, gdy jest to pierwsza kolumna. Wywołanie `utils.get_column_index()` prawidłowo zwraca wówczas indeks `0`, ale asercja ewaluuje tę wartość jako `False`. Po tej poprawce, asercja akceptuje każdą wartość która nie jest `None`.